### PR TITLE
Add full Kubernetes practice manifests and improved README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,337 +1,166 @@
 # Prácticas básicas de Kubernetes con kind
 
-Estas prácticas están diseñadas para que los alumnos aprendan los conceptos fundamentales de Kubernetes utilizando kind (Kubernetes IN Docker).
+Este repositorio contiene las guías y los manifiestos necesarios para realizar
+seis prácticas introductorias de Kubernetes utilizando [kind](https://kind.sigs.k8s.io/).
+Cada práctica está pensada para ejecutarse en un entorno local con Docker
+instalado.
 
----
+## Requisitos previos
+
+- Docker y [kind](https://kind.sigs.k8s.io/) instalados.
+- `kubectl` configurado para usar el clúster de kind.
+
+## Estructura del repositorio
+
+| Archivo | Descripción |
+|---------|-------------|
+| `nginx-pod.yaml` | Manifiesto para crear un pod sencillo con Nginx. |
+| `nginx-deployment.yaml` | Deployment con réplicas de Nginx. |
+| `nginx-service.yaml` | Exposición del deployment mediante un `Service`. |
+| `mensaje.txt` | Archivo de ejemplo usado para crear un ConfigMap. |
+| `pod-con-configmap.yaml` | Pod que monta el ConfigMap anterior. |
+| `volumenes.yaml` | Ejemplo de `PersistentVolume`, `PersistentVolumeClaim` y pod. |
+| `pod-secreto.yaml` | Pod que obtiene una variable de un Secret. |
+| `nginx-probe.yaml` | Pod con probes de liveness y readiness. |
 
 ## Práctica 1: Crear un clúster con kind y desplegar un Pod
 
 ### Objetivo
+Configurar un clúster local con kind y desplegar un pod sencillo.
 
-- Instalar y usar kind para levantar un clúster de Kubernetes local.
-- Desplegar un pod básico usando un archivo YAML.
-
-### Instrucciones
-
+### Pasos
 1. Crear el clúster:
-
    ```bash
    kind create cluster --name practicas-k8s
    ```
-
-2. Verificar los nodos:
-
+2. Verificar los nodos del clúster:
    ```bash
    kubectl get nodes
    ```
-
-3. Crear el archivo `nginx-pod.yaml`:
-
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: nginx
-   spec:
-     containers:
-       - name: nginx
-         image: nginx:latest
-         ports:
-           - containerPort: 80
-   ```
-
-4. Aplicar y verificar:
+3. Crear el pod ejecutando:
    ```bash
    kubectl apply -f nginx-pod.yaml
+   ```
+4. Comprobar que el pod está en ejecución y ver los logs:
+   ```bash
    kubectl get pods
    kubectl logs nginx
    ```
-
-### Desafío opcional
-
-- Cambiar la imagen del contenedor por `httpd` y probar nuevamente.
+5. **Desafío**: cambia la imagen a `httpd` en el manifiesto y vuelve a crear el pod.
 
 ---
 
 ## Práctica 2: Deployment y Service
 
 ### Objetivo
+Desplegar Nginx utilizando un Deployment y exponerlo mediante un Service de tipo NodePort.
 
-- Crear un Deployment para manejar réplicas.
-- Exponer el servicio usando NodePort.
-
-### Instrucciones
-
-1. Crear el archivo `nginx-deployment.yaml`:
-
-   ```yaml
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: nginx-deploy
-   spec:
-     replicas: 2
-     selector:
-       matchLabels:
-         app: nginx
-     template:
-       metadata:
-         labels:
-           app: nginx
-       spec:
-         containers:
-           - name: nginx
-             image: nginx
-             ports:
-               - containerPort: 80
-   ```
-
-2. Aplicar el Deployment:
-
+### Pasos
+1. Aplicar el deployment:
    ```bash
    kubectl apply -f nginx-deployment.yaml
+   ```
+2. Ver los pods creados:
+   ```bash
    kubectl get pods -l app=nginx
    ```
-
-3. Crear el archivo `nginx-service.yaml`:
-
-   ```yaml
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: nginx-service
-   spec:
-     type: NodePort
-     selector:
-       app: nginx
-     ports:
-       - port: 80
-         targetPort: 80
-         nodePort: 30080
-   ```
-
-4. Aplicar el Service y probar:
+3. Exponer el servicio:
    ```bash
    kubectl apply -f nginx-service.yaml
-   kubectl port-forward services/nginx-service 8080:80
+   ```
+4. Probar accediendo en el navegador o con `curl`:
+   ```bash
+   kubectl port-forward service/nginx-service 8080:80
    curl http://localhost:8080
    ```
-
-### Desafío opcional
-
-- Aumentar el número de réplicas a 5 y verificar el balanceo de carga usando `watch curl`.
+5. **Desafío**: escala el deployment a 5 réplicas y observa el balanceo de carga.
 
 ---
 
 ## Práctica 3: ConfigMaps y montado en pods
 
 ### Objetivo
+Crear un ConfigMap a partir de un archivo y montarlo en un contenedor.
 
-- Crear un ConfigMap desde un archivo.
-- Montarlo en un contenedor y visualizar su contenido.
-
-### Instrucciones
-
-1. Crear un archivo de configuración:
-
-   ```bash
-   echo "Bienvenido a Kubernetes" > mensaje.txt
-   ```
-
-2. Crear el ConfigMap:
-
+### Pasos
+1. Generar el ConfigMap:
    ```bash
    kubectl create configmap mensaje-config --from-file=mensaje.txt
    ```
-
-3. Crear el archivo `pod-con-configmap.yaml`:
-
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: pod-con-configmap
-   spec:
-     containers:
-       - name: busybox
-         image: busybox
-         command: ["sleep", "3600"]
-         volumeMounts:
-           - name: mensaje-vol
-             mountPath: "/config"
-     volumes:
-       - name: mensaje-vol
-         configMap:
-           name: mensaje-config
-   ```
-
-4. Aplicar y verificar:
+2. Crear el pod:
    ```bash
    kubectl apply -f pod-con-configmap.yaml
+   ```
+3. Verificar el contenido del ConfigMap dentro del contenedor:
+   ```bash
    kubectl exec -it pod-con-configmap -- cat /config/mensaje.txt
    ```
-
-### Desafío opcional
-
-- Modificar el contenido del archivo, volver a crear el ConfigMap y reiniciar el pod.
+4. **Desafío**: modifica `mensaje.txt`, vuelve a crear el ConfigMap y reinicia el pod.
 
 ---
 
-## Práctica 4: Volúmenes Persistentes
+## Práctica 4: Volúmenes persistentes
 
 ### Objetivo
-- Usar un volumen persistente local para guardar datos.
-- Comprobar que los datos persisten aunque el pod se reinicie.
+Usar un volumen local para almacenar datos que sobrevivan a reinicios del pod.
 
-### Instrucciones
-1. Crear un `PersistentVolume` y `PersistentVolumeClaim`:
-   ```yaml
-   apiVersion: v1
-   kind: PersistentVolume
-   metadata:
-     name: local-pv
-   spec:
-     capacity:
-       storage: 1Gi
-     accessModes:
-       - ReadWriteOnce
-     hostPath:
-       path: "/tmp/kind-pv"
-   ---
-   apiVersion: v1
-   kind: PersistentVolumeClaim
-   metadata:
-     name: local-pvc
-   spec:
-     accessModes:
-       - ReadWriteOnce
-     resources:
-       requests:
-         storage: 1Gi
-   ```
-
-2. Crear un pod que use este volumen:
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: pod-con-pv
-   spec:
-     containers:
-     - name: busybox
-       image: busybox
-       command: [ "sh", "-c", "echo 'Hola desde PV' > /data/hola.txt && sleep 3600" ]
-       volumeMounts:
-       - mountPath: "/data"
-         name: volumen-pv
-     volumes:
-     - name: volumen-pv
-       persistentVolumeClaim:
-         claimName: local-pvc
-   ```
-
-3. Aplicar todo y verificar:
+### Pasos
+1. Crear los recursos necesarios:
    ```bash
    kubectl apply -f volumenes.yaml
+   ```
+2. Verificar que el archivo se ha creado en el volumen:
+   ```bash
    kubectl exec -it pod-con-pv -- cat /data/hola.txt
    ```
-
-4. Eliminar el pod y volverlo a crear para comprobar persistencia.
-
-### Desafío opcional
-- Montar el volumen en otro pod para compartir los datos.
+3. Eliminar y volver a crear el pod para comprobar que el archivo persiste.
+4. **Desafío**: monta el mismo volumen en otro pod para compartir datos.
 
 ---
 
 ## Práctica 5: Variables de entorno y secretos
 
 ### Objetivo
-- Crear un Secret y usarlo como variable de entorno en un pod.
+Crear un Secret y usarlo como variable de entorno en un contenedor.
 
-### Instrucciones
-1. Crear un Secret:
+### Pasos
+1. Crear el Secret:
    ```bash
    kubectl create secret generic mi-secreto --from-literal=CLAVE_API=12345
    ```
-
-2. Crear el pod:
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: pod-secreto
-   spec:
-     containers:
-     - name: alpine
-       image: alpine
-       command: ["sh", "-c", "env | grep CLAVE_API && sleep 3600"]
-       env:
-       - name: CLAVE_API
-         valueFrom:
-           secretKeyRef:
-             name: mi-secreto
-             key: CLAVE_API
-   ```
-
-3. Aplicar y verificar:
+2. Desplegar el pod:
    ```bash
    kubectl apply -f pod-secreto.yaml
+   ```
+3. Comprobar el valor de la variable de entorno:
+   ```bash
    kubectl exec -it pod-secreto -- env | grep CLAVE_API
    ```
-
-### Desafío opcional
-- Usar un ConfigMap y un Secret juntos para inyectar variables en el pod.
+4. **Desafío**: combina un ConfigMap y un Secret para pasar varias variables.
 
 ---
 
 ## Práctica 6: Health Checks (Probes)
 
 ### Objetivo
-- Definir readiness y liveness probes para un contenedor.
+Definir readiness y liveness probes para un contenedor de Nginx.
 
-### Instrucciones
-1. Crear el archivo `nginx-probe.yaml`:
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: nginx-con-probes
-   spec:
-     containers:
-     - name: nginx
-       image: nginx
-       ports:
-       - containerPort: 80
-       readinessProbe:
-         httpGet:
-           path: /
-           port: 80
-         initialDelaySeconds: 5
-         periodSeconds: 10
-       livenessProbe:
-         httpGet:
-           path: /
-           port: 80
-         initialDelaySeconds: 15
-         periodSeconds: 20
-   ```
-
-2. Aplicar y verificar:
+### Pasos
+1. Crear el pod con probes:
    ```bash
    kubectl apply -f nginx-probe.yaml
+   ```
+2. Consultar la descripción del pod y observar los eventos:
+   ```bash
    kubectl describe pod nginx-con-probes
    ```
-
-### Desafío opcional
-- Cambiar la `livenessProbe` para que apunte a una ruta inexistente y observar el reinicio del pod.
+3. **Desafío**: modifica la `livenessProbe` para que falle y comprueba que el pod se reinicia.
 
 ---
 
 ## Limpieza
 
-Para eliminar el clúster:
-
+Para eliminar el clúster de kind y todos los recursos creados:
 ```bash
 kind delete cluster --name practicas-k8s
-
 ```

--- a/mensaje.txt
+++ b/mensaje.txt
@@ -1,0 +1,1 @@
+Bienvenido a Kubernetes

--- a/nginx-deployment.yaml
+++ b/nginx-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deploy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80

--- a/nginx-pod.yaml
+++ b/nginx-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+      ports:
+        - containerPort: 80

--- a/nginx-probe.yaml
+++ b/nginx-probe.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-con-probes
+spec:
+  containers:
+    - name: nginx
+      image: nginx
+      ports:
+        - containerPort: 80
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 15
+        periodSeconds: 20

--- a/nginx-service.yaml
+++ b/nginx-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  type: NodePort
+  selector:
+    app: nginx
+  ports:
+    - port: 80
+      targetPort: 80
+      nodePort: 30080

--- a/pod-con-configmap.yaml
+++ b/pod-con-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-con-configmap
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      command: ["sleep", "3600"]
+      volumeMounts:
+        - name: mensaje-vol
+          mountPath: "/config"
+  volumes:
+    - name: mensaje-vol
+      configMap:
+        name: mensaje-config

--- a/pod-secreto.yaml
+++ b/pod-secreto.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-secreto
+spec:
+  containers:
+    - name: alpine
+      image: alpine
+      command: ["sh", "-c", "env | grep CLAVE_API && sleep 3600"]
+      env:
+        - name: CLAVE_API
+          valueFrom:
+            secretKeyRef:
+              name: mi-secreto
+              key: CLAVE_API

--- a/volumenes.yaml
+++ b/volumenes.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/kind-pv"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-con-pv
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      command: [ "sh", "-c", "echo 'Hola desde PV' > /data/hola.txt && sleep 3600" ]
+      volumeMounts:
+        - mountPath: "/data"
+          name: volumen-pv
+  volumes:
+    - name: volumen-pv
+      persistentVolumeClaim:
+        claimName: local-pvc


### PR DESCRIPTION
## Summary
- expand README with clearer instructions for six Kubernetes practices
- include manifests referenced in the README
- provide example configuration file for ConfigMap

## Testing
- `yamllint *.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448ac5be60832eb3c2f62fbddbf042