### PR TITLE
Fix README instructions and add YAML tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Prácticas básicas de Kubernetes con kind
 
-Este repositorio contiene las guías y los manifiestos necesarios para realizar
-seis prácticas introductorias de Kubernetes utilizando [kind](https://kind.sigs.k8s.io/).
-Cada práctica está pensada para ejecutarse en un entorno local con Docker
-instalado.
+Este repositorio contiene las guías y los manifiestos necesarios para realizar seis prácticas introductorias de Kubernetes utilizando [kind](https://kind.sigs.k8s.io/). Cada práctica está pensada para ejecutarse en un entorno local con Docker instalado.
 
 ## Requisitos previos
 
@@ -69,10 +66,9 @@ Desplegar Nginx utilizando un Deployment y exponerlo mediante un Service de tipo
    kubectl apply -f nginx-service.yaml
    ```
 4. Probar accediendo en el navegador o con `curl`:
-   ```bash
-   kubectl port-forward service/nginx-service 8080:80
-   curl http://localhost:8080
-   ```
+    ```bash
+    curl http://localhost:30080
+    ```
 5. **Desafío**: escala el deployment a 5 réplicas y observa el balanceo de carga.
 
 ---
@@ -105,7 +101,7 @@ Crear un ConfigMap a partir de un archivo y montarlo en un contenedor.
 Usar un volumen local para almacenar datos que sobrevivan a reinicios del pod.
 
 ### Pasos
-1. Crear los recursos necesarios:
+1. Crear los recursos necesarios con el manifiesto `volumenes.yaml`:
    ```bash
    kubectl apply -f volumenes.yaml
    ```
@@ -163,4 +159,11 @@ Definir readiness y liveness probes para un contenedor de Nginx.
 Para eliminar el clúster de kind y todos los recursos creados:
 ```bash
 kind delete cluster --name practicas-k8s
+```
+
+## Pruebas
+
+Para ejecutar las pruebas automatizadas:
+```bash
+pytest
 ```

--- a/tests/test_readme_yaml.py
+++ b/tests/test_readme_yaml.py
@@ -1,0 +1,22 @@
+import re
+import pathlib
+import pytest
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+README_PATH = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+
+YAML_BLOCK_RE = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
+
+def test_yaml_blocks_parse():
+    content = README_PATH.read_text(encoding='utf-8')
+    blocks = YAML_BLOCK_RE.findall(content)
+    if not blocks:
+        pytest.skip("No YAML blocks found in README")
+    if yaml is None:
+        pytest.fail("PyYAML is not installed")
+    for block in blocks:
+        yaml.safe_load(block)


### PR DESCRIPTION
## Summary
- fix broken lines at the beginning of the README
- clarify NodePort usage and volume instructions
- document how to run tests
- add pytest check for YAML code blocks in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448a371bec832e8a42c2f660a730cc