### PR TITLE
Add advanced Kubernetes practice guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Este repositorio contiene las guías y los manifiestos necesarios para realizar 
 | `volumenes.yaml` | Ejemplo de `PersistentVolume`, `PersistentVolumeClaim` y pod. |
 | `pod-secreto.yaml` | Pod que obtiene una variable de un Secret. |
 | `nginx-probe.yaml` | Pod con probes de liveness y readiness. |
+| `ingress.yaml` | Ingress que expone el servicio de Nginx. |
+| `statefulset.yaml` | StatefulSet con almacenamiento persistente. |
+| `job.yaml` | Job que ejecuta un comando y termina. |
+| `cronjob.yaml` | CronJob programado periódicamente. |
+| `network-policy.yaml` | NetworkPolicy que limita el tráfico. |
+| `hpa.yaml` | HPA para escalar el deployment. |
+| `daemonset.yaml` | DaemonSet que corre en todos los nodos. |
+| `rbac.yaml` | Ejemplo de ServiceAccount y RBAC. |
 
 ## Práctica 1: Crear un clúster con kind y desplegar un Pod
 
@@ -151,6 +159,129 @@ Definir readiness y liveness probes para un contenedor de Nginx.
    kubectl describe pod nginx-con-probes
    ```
 3. **Desafío**: modifica la `livenessProbe` para que falle y comprueba que el pod se reinicia.
+
+---
+
+## Práctica 7: Ingress básico
+
+### Objetivo
+Exponer el servicio Nginx mediante un recurso Ingress.
+
+### Pasos
+1. Asegúrate de haber creado el `nginx-service` de la práctica 2.
+2. Aplica el manifiesto:
+   ```bash
+   kubectl apply -f ingress.yaml
+   ```
+3. Añade en tu `/etc/hosts` la línea `127.0.0.1 local.example.com`.
+4. Accede a `http://local.example.com` para comprobar la respuesta.
+5. **Desafío**: agrega otra regla al Ingress para un host o ruta distinta.
+
+---
+
+## Práctica 8: StatefulSet con almacenamiento
+
+### Objetivo
+Desplegar un StatefulSet que mantenga datos persistentes.
+
+### Pasos
+1. Crear los recursos:
+   ```bash
+   kubectl apply -f statefulset.yaml
+   ```
+2. Observa los PVC generados para cada réplica del StatefulSet.
+3. Escribe un archivo en uno de los pods y verifica que persiste tras reiniciar dicho pod.
+4. **Desafío**: escala el StatefulSet y revisa la creación de nuevos volúmenes.
+
+---
+
+## Práctica 9: Jobs
+
+### Objetivo
+Ejecutar un trabajo que finaliza una vez completada la tarea.
+
+### Pasos
+1. Crear el Job:
+   ```bash
+   kubectl apply -f job.yaml
+   ```
+2. Espera a que termine y revisa los logs con `kubectl logs job/fecha-job`.
+3. **Desafío**: modifica el comando para que falle y observa el `backoffLimit`.
+
+---
+
+## Práctica 10: CronJobs
+
+### Objetivo
+Programar tareas periódicas dentro del clúster.
+
+### Pasos
+1. Desplegar el CronJob:
+   ```bash
+   kubectl apply -f cronjob.yaml
+   ```
+2. Esperar unos minutos y listar los Jobs creados.
+3. **Desafío**: cambia la periodicidad a cada 5 minutos.
+
+---
+
+## Práctica 11: Network Policies
+
+### Objetivo
+Restringir el tráfico hacia los pods de Nginx.
+
+### Pasos
+1. Aplicar la política de red:
+   ```bash
+   kubectl apply -f network-policy.yaml
+   ```
+2. Crea un pod `busybox` con la etiqueta `access=granted` e intenta acceder al servicio.
+3. **Desafío**: prueba desde un pod sin la etiqueta y verifica que la conexión es rechazada.
+
+---
+
+## Práctica 12: Autoscaling con HPA
+
+### Objetivo
+Escalar el deployment de Nginx automáticamente según el uso de CPU.
+
+### Pasos
+1. Aplica el manifiesto del autoscaler:
+   ```bash
+   kubectl apply -f hpa.yaml
+   ```
+2. Genera carga para observar el aumento de réplicas.
+3. **Desafío**: ajusta el valor de `averageUtilization` y analiza el comportamiento.
+
+---
+
+## Práctica 13: DaemonSets
+
+### Objetivo
+Ejecutar un contenedor en cada nodo del clúster.
+
+### Pasos
+1. Crear el DaemonSet:
+   ```bash
+   kubectl apply -f daemonset.yaml
+   ```
+2. Comprueba que se creó un pod por nodo con `kubectl get pods -o wide`.
+3. **Desafío**: agrega tolerations para que se ejecute también en nodos con taints.
+
+---
+
+## Práctica 14: ServiceAccounts y RBAC
+
+### Objetivo
+Crear una cuenta de servicio con permisos limitados para listar pods.
+
+### Pasos
+1. Desplegar los recursos:
+   ```bash
+   kubectl apply -f rbac.yaml
+   ```
+2. Usa esa cuenta para intentar listar los pods del namespace.
+3. **Desafío**: extiende la `Role` para permitir la creación de pods y comprueba el cambio.
 
 ---
 

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: saludo-cron
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: saludo
+              image: busybox
+              command: ["sh", "-c", "date; echo Hola"]
+          restartPolicy: OnFailure

--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: logger
+spec:
+  selector:
+    matchLabels:
+      app: logger
+  template:
+    metadata:
+      labels:
+        app: logger
+    spec:
+      containers:
+        - name: logger
+          image: busybox
+          command: ["sh", "-c", "while true; do echo log from $(hostname); sleep 30; done"]

--- a/hpa.yaml
+++ b/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginx-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx-deploy
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+spec:
+  rules:
+    - host: local.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
+                port:
+                  number: 80

--- a/job.yaml
+++ b/job.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fecha-job
+spec:
+  template:
+    spec:
+      containers:
+        - name: fecha
+          image: busybox
+          command: ["sh", "-c", "date; echo Fin"]
+      restartPolicy: Never
+  backoffLimit: 2

--- a/network-policy.yaml
+++ b/network-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: nginx-allow-from-busybox
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              access: granted

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lector-pods
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rol-lectura
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vinculacion-lectura
+subjects:
+  - kind: ServiceAccount
+    name: lector-pods
+roleRef:
+  kind: Role
+  name: rol-lectura
+  apiGroup: rbac.authorization.k8s.io

--- a/statefulset.yaml
+++ b/statefulset.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 80
+      name: web
+  clusterIP: None
+  selector:
+    app: web
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: "web"
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 100Mi


### PR DESCRIPTION
## Summary
- expand file manifest table in README
- add eight new practice sections covering Ingress, StatefulSets, Jobs, CronJobs, NetworkPolicies, HPAs, DaemonSets and RBAC
- provide example manifests for each new practice

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68450e91be20832e8fec128f09588689